### PR TITLE
chore: override proc-macro2 version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -472,6 +472,7 @@ dependencies = [
  "clap",
  "console",
  "dialoguer",
+ "proc-macro2",
  "serde_json",
  "spinach",
  "tokio",
@@ -1084,9 +1085,9 @@ checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.53"
+version = "1.0.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba466839c78239c09faf015484e5cc04860f88242cff4d03eb038f04b4699b73"
+checksum = "7b368fba921b0dce7e60f5e04ec15e565b3303972b42bcfde1d0713b881959eb"
 dependencies = [
  "unicode-ident",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ dialoguer = "0.10.4"
 serde_json = "1.0.99"
 spinach = "2.1.0"
 tokio = { version = "1", features = ["full"] }
+proc-macro2 = "1.0.63" # override indirect dependency
 
 [dependencies.uuid]
 version = "1.3.4"


### PR DESCRIPTION
The package proc-macro2 is used by couple of dependencies, which have outdated versions and at least one (tower) doesn't look like it's gonna be updated anytime soon.

proc-macro2 needs to be updated to at least 1.0.60 to be working on nightly. dtolnay/proc-macro2#398