### PR TITLE
chore: updates aws_config's BehaviorVersion from v2023_11_09 to v2024_03_28

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -36,7 +36,7 @@ struct Args {
 async fn main() -> Result<(), Box<dyn Error>> {
     let args = Args::parse();
 
-    let config = aws_config::load_defaults(BehaviorVersion::v2023_11_09()).await;
+    let config = aws_config::load_defaults(BehaviorVersion::v2024_03_28()).await;
     let client = cloudformation::Client::new(&config);
     let stacks = get_stacks(&client).await?;
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated configuration setup to use the latest default behavior version for AWS services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->