### PR TITLE
feat: Updates supported resource types (6)

### DIFF
--- a/src/supported_resource_types.rs
+++ b/src/supported_resource_types.rs
@@ -1,4 +1,4 @@
-pub static SUPPORTED_RESOURCE_TYPES: [&str; 1246] = [
+pub static SUPPORTED_RESOURCE_TYPES: [&str; 1240] = [
     "AWS::ACMPCA::Certificate",
     "AWS::ACMPCA::CertificateAuthority",
     "AWS::ACMPCA::CertificateAuthorityActivation",
@@ -992,12 +992,6 @@ pub static SUPPORTED_RESOURCE_TYPES: [&str; 1246] = [
     "AWS::ResourceExplorer2::View",
     "AWS::ResourceGroups::Group",
     "AWS::ResourceGroups::TagSyncTask",
-    "AWS::RoboMaker::Fleet",
-    "AWS::RoboMaker::Robot",
-    "AWS::RoboMaker::RobotApplication",
-    "AWS::RoboMaker::RobotApplicationVersion",
-    "AWS::RoboMaker::SimulationApplication",
-    "AWS::RoboMaker::SimulationApplicationVersion",
     "AWS::RolesAnywhere::CRL",
     "AWS::RolesAnywhere::Profile",
     "AWS::RolesAnywhere::TrustAnchor",


### PR DESCRIPTION
**Removed resources:**
  - AWS::RoboMaker::Fleet
  - AWS::RoboMaker::Robot
  - AWS::RoboMaker::RobotApplication
  - AWS::RoboMaker::RobotApplicationVersion
  - AWS::RoboMaker::SimulationApplication
  - AWS::RoboMaker::SimulationApplicationVersion


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the supported resource types list to reflect current availability.
  - Removed six AWS RoboMaker resource types: AWS::RoboMaker::Fleet, AWS::RoboMaker::Robot, AWS::RoboMaker::RobotApplication, AWS::RoboMaker::RobotApplicationVersion, AWS::RoboMaker::SimulationApplication, AWS::RoboMaker::SimulationApplicationVersion.
  - Total supported types reduced from 1246 to 1240.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->