### PR TITLE
chore: configure renovate to prevent merge conflicts

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,8 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended", ":semanticCommitTypeAll(chore)"],
   "dependencyDashboard": false,
+  "prConcurrentLimit": 1,
+  "prHourlyLimit": 1,
   "ignorePaths": [
     "**/node_modules/**",
     "**/bower_components/**",
@@ -20,5 +22,5 @@
       "rangeStrategy": "bump"
     }
   ],
-  "rebaseWhen": "auto"
+  "rebaseWhen": "conflicted"
 }


### PR DESCRIPTION
## Summary

Fixes the issue where Renovate creates multiple PRs in parallel that conflict with each other after one gets merged.

## Changes

- **prConcurrentLimit: 1** - Limits Renovate to only 1 open PR at a time
- **prHourlyLimit: 1** - Limits PR creation rate to 1 per hour
- **rebaseWhen: "conflicted"** - Changed from "auto" to "conflicted" to ensure automatic rebasing when merge conflicts occur

## Impact

- Only one dependency update PR will be active at a time
- When a PR is merged, Renovate will create the next one
- No more manual branch updates needed due to merge conflicts
- Slower update cadence but fully automated workflow