### PR TITLE
chore: migrate GitHub workflows from static credentials to OIDC authentication

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -277,6 +277,9 @@ jobs:
     needs: changes
     if: needs.changes.outputs.src == 'true'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       matrix:
         template:
@@ -291,12 +294,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
 
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Deploy stack
         working-directory: test/cloudformation
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
         run: |
           # Extract stack name from template filename (remove extension)
           STACK_NAME="${{ matrix.template }}"
@@ -340,6 +345,9 @@ jobs:
       - build
       - prepare-stacks
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -349,6 +357,12 @@ jobs:
         with:
           name: cfn-teleport-binary
           path: /tmp/cfn-teleport-bin
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install binary
         run: |
@@ -488,9 +502,6 @@ jobs:
             exit 1
           fi
         env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           STACK1: CfnTeleportRefactorTest1
           STACK2: CfnTeleportRefactorTest2
           BUCKET1: Bucket182C536A1
@@ -503,6 +514,9 @@ jobs:
       - build
       - prepare-stacks
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -512,6 +526,12 @@ jobs:
         with:
           name: cfn-teleport-binary
           path: /tmp/cfn-teleport-bin
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install binary
         run: |
@@ -571,9 +591,6 @@ jobs:
             exit 1
           fi
         env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           STACK1: CfnTeleportImportTest1
           STACK2: CfnTeleportImportTest2
           BUCKET1: Bucket182C536A1
@@ -586,6 +603,9 @@ jobs:
       - build
       - prepare-stacks
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -595,6 +615,12 @@ jobs:
         with:
           name: cfn-teleport-binary
           path: /tmp/cfn-teleport-bin
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install binary
         run: |
@@ -772,9 +798,6 @@ jobs:
           echo "✓ All same-stack rename tests passed and resources restored!"
           echo "=========================================="
         env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           STACK1: CfnTeleportRenameTest1
 
   # Template I/O tests (export, file input, migration spec)
@@ -783,6 +806,9 @@ jobs:
       - build
       - prepare-stacks
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -792,6 +818,12 @@ jobs:
         with:
           name: cfn-teleport-binary
           path: /tmp/cfn-teleport-bin
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Install binary
         run: |
@@ -1084,9 +1116,6 @@ jobs:
           echo "✓ All template I/O tests passed!"
           echo "=========================================="
         env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           STACK1: CfnTeleportRefactorTest1
           STACK2: CfnTeleportRefactorTest2
           IMPORT_STACK1: CfnTeleportImportTest1
@@ -1098,6 +1127,9 @@ jobs:
       - build-windows
       - prepare-stacks
     runs-on: windows-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -1107,6 +1139,12 @@ jobs:
         with:
           name: cfn-teleport-windows-binary
           path: C:\cfn-teleport-bin
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Test Windows binary with real AWS resources
         shell: pwsh
@@ -1181,10 +1219,6 @@ jobs:
           Write-Host "=========================================="
           Write-Host "✅ All Windows binary tests passed!"
           Write-Host "=========================================="
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   # Verify stack template formats and resource state
   verify-state:
@@ -1196,11 +1230,20 @@ jobs:
       - test-template-io
     if: always()
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     outputs:
       state_valid: ${{ steps.check.outputs.state_valid }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Verify stack formats and resources match original templates
         id: check
@@ -1342,10 +1385,6 @@ jobs:
             echo "state_valid=false" >> $GITHUB_OUTPUT
             exit 1
           fi
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   # Delete stacks in parallel (only if verification failed)
   delete-stacks:
@@ -1353,6 +1392,9 @@ jobs:
       - verify-state
     if: always() && needs.prepare-stacks.result != 'skipped' && needs.verify-state.outputs.state_valid != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -1365,6 +1407,12 @@ jobs:
           - CfnTeleportWindowsTest1
           - CfnTeleportWindowsTest2
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
+
       - name: Delete stack ${{ matrix.stack }}
         run: |
           echo "Deleting stack: ${{ matrix.stack }}"
@@ -1374,10 +1422,6 @@ jobs:
           aws cloudformation wait stack-delete-complete --stack-name ${{ matrix.stack }} || true
 
           echo "✅ Stack ${{ matrix.stack }} deleted"
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   # Cleanup remaining resources (runs after parallel stack deletion)
   cleanup-resources:
@@ -1385,9 +1429,18 @@ jobs:
       - delete-stacks
     if: always() && needs.prepare-stacks.result != 'skipped' && needs.verify-state.outputs.state_valid != 'true'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v5.1.1
+        with:
+          role-to-assume: ${{ secrets.AWS_IAM_ROLE }}
+          aws-region: ${{ secrets.AWS_REGION }}
 
       - name: Clean up any remaining tagged resources
         run: |
@@ -1395,10 +1448,6 @@ jobs:
           echo "Cleaning up any remaining test resources"
           echo "=========================================="
           make test-clean-all
-        env:
-          AWS_DEFAULT_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
   report-status:
     name: success


### PR DESCRIPTION
## Summary

Migrates the `pr-test.yml` workflow from static AWS credentials (AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY) to OIDC-based authentication using GitHub's native OIDC token provider. This improves security by eliminating long-lived credentials and provides better audit trails through AWS CloudTrail.

### Changes Made

- ✅ Updated all 9 AWS credential usages across 6 jobs in `pr-test.yml`
- ✅ Added `permissions` blocks (id-token: write, contents: read) to all AWS-using jobs
- ✅ Added `Configure AWS Credentials` step using `aws-actions/configure-aws-credentials@v5.1.1`
- ✅ Removed all static credential environment variables (AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_DEFAULT_REGION)
- ✅ Region now configured via `AWS_REGION` secret for flexibility

### Jobs Updated

1. **prepare-stacks** - CloudFormation stack deployment
2. **test-refactor** - Resource refactoring tests
3. **test-import** - Resource import tests
4. **test-rename** - Resource renaming tests
5. **test-template-io** - Template I/O tests
6. **test-windows** - Windows binary tests
7. **verify-state** - Stack state verification
8. **delete-stacks** - Stack cleanup (failure recovery)
9. **cleanup-resources** - Resource cleanup (failure recovery)

### Security Benefits

- **No long-lived credentials** - Tokens are short-lived (1 hour default)
- **Better audit trail** - CloudTrail shows GitHub Actions OIDC principal
- **Actor restriction** - IAM trust policy restricts to repository owner only
- **Principle of least privilege** - IAM role can have scoped permissions

## Prerequisites (REQUIRED before merge)

⚠️ **These steps must be completed before this PR can be tested or merged:**

### 1. Verify GitHub OIDC Provider in AWS IAM

Check if the OIDC provider exists:
- **Provider URL**: `https://token.actions.githubusercontent.com`
- **Audience**: `sts.amazonaws.com`

If missing, create it following [AWS documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services).

### 2. Create IAM Role for GitHub Actions

Create an IAM role with the following configuration:

**Role Name**: `GitHubActions-cfn-teleport-ci` (or your preferred name)

**Trust Policy**:
```json
{
  "Version": "2012-10-17",
  "Statement": [
    {
      "Effect": "Allow",
      "Principal": {
        "Federated": "arn:aws:iam::YOUR_ACCOUNT_ID:oidc-provider/token.actions.githubusercontent.com"
      },
      "Action": "sts:AssumeRoleWithWebIdentity",
      "Condition": {
        "StringEquals": {
          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com",
          "token.actions.githubusercontent.com:sub": "repo:udondan/cfn-teleport:*"
        },
        "StringLike": {
          "token.actions.githubusercontent.com:actor": "udondan"
        }
      }
    }
  ]
}
```

**Required Permissions** (attach managed policies or create custom policy):
- CloudFormation: `cloudformation:*` (or scoped to specific operations)
- S3: `s3:*` (for test bucket operations)
- DynamoDB: `dynamodb:*` (for test table operations)
- EC2: `ec2:*` (for test instance/security group/key pair operations)
- IAM: `iam:*Role*`, `iam:*Policy*`, `iam:GetInstanceProfile`, etc.

### 3. Configure GitHub Repository Secrets

Add the following secrets to the repository:

1. **AWS_IAM_ROLE**
   - Value: `arn:aws:iam::YOUR_ACCOUNT_ID:role/GitHubActions-cfn-teleport-ci`
   - This is the ARN of the role created in step 2

2. **AWS_REGION**
   - Value: `us-east-1`
   - Can be changed if you want to run tests in a different region

**Do NOT remove the old secrets yet** - keep them as backup for 1-2 weeks:
- `AWS_ACCESS_KEY_ID` (keep for rollback)
- `AWS_SECRET_ACCESS_KEY` (keep for rollback)

## Testing Plan

Once prerequisites are complete:

1. ✅ YAML syntax validated (passed locally)
2. ⏳ Trigger workflow on this PR to test OIDC authentication
3. ⏳ Verify all 6 test jobs authenticate successfully
4. ⏳ Verify CloudFormation operations complete successfully
5. ⏳ Check AWS CloudTrail for `AssumeRoleWithWebIdentity` events
6. ⏳ Confirm actor shows as "udondan" in CloudTrail logs

## Rollback Procedure

If issues occur after merge:

1. **Immediate rollback**:
   ```bash
   git revert <merge-commit-sha>
   git push origin main
   ```

2. **Temporary fix** (if OIDC fails but old secrets still exist):
   - Revert the workflow file changes
   - Old static credentials will work as before

3. **After 1-2 weeks of stability**:
   - Remove old secrets: `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`
   - Optionally revoke old IAM access key in AWS console

## Post-Merge Checklist

- [ ] Monitor first workflow run on main branch
- [ ] Watch subsequent PR test runs for 1-2 weeks
- [ ] Check CloudTrail regularly for unusual activity
- [ ] After stability period: Remove old AWS secrets
- [ ] After stability period: Optionally revoke old IAM access key

## References

- [GitHub Actions OIDC Documentation](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect)
- [aws-actions/configure-aws-credentials](https://github.com/aws-actions/configure-aws-credentials)
- [AWS CloudFormation Documentation](https://docs.aws.amazon.com/cloudformation/)

---

**Impact**: Breaking change - requires AWS IAM role and GitHub secrets configuration before merge
**Files Changed**: 1 file, +81 insertions, -32 deletions
**Commit**: bf03740